### PR TITLE
Article parent nested schema

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,6 @@
     "rules": {
         "max-len": "off",
         "consistent-return": "off",
+        "no-trailing-spaces": "error",
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "postinstall": "bower install",
     "webpack": "webpack --watch",
     "lint": "eslint src",
-    "lint-watch": "esw -w --changed src"
+    "lint-watch": "esw -w --changed src",
+    "autoformat": "eslint src --fix"
   },
   "dependencies": {
     "apollo-client": "^1.7.0",

--- a/src/admin/controllers/articles/index.js
+++ b/src/admin/controllers/articles/index.js
@@ -155,18 +155,6 @@ router.post('/:id/imagedelete', formidable(), (req, res) => {
   });
 });
 
-router.get('/search', (req, res) => {
-  var regex = new RegExp(`^${req.query.title}`);
-  Article.find({
-    title: regex,
-  }, (err, articles) => {
-    if (err) {
-      console.log(err);
-    }
-    res.send(articles);
-  });
-});
-
 router.get('/docs/search', (req, res) => {
   getGoogleDriveClient(driveClient, function(err, drive) {
     if (err) {

--- a/src/admin/frontend/components/article-edit.js
+++ b/src/admin/frontend/components/article-edit.js
@@ -17,7 +17,7 @@ const editableArticleFields = [
   'is_featured',
   'cover',
   'thumb',
-  'parent',
+  'parentID',
   'topicID',
 ];
 
@@ -35,6 +35,8 @@ function getInputKey(key) {
   switch (key) {
     case 'topicID':
       return 'topic';
+    case 'parentID':
+      return 'parent';
     default:
       return key;
   }

--- a/src/admin/frontend/gql/queries.js
+++ b/src/admin/frontend/gql/queries.js
@@ -15,7 +15,10 @@ export const ARTICLE_QUERY = gql`
       is_featured
       cover
       thumb
-      parent
+      parent {
+        _id
+        title
+      }
       topic {
         _id
         title

--- a/src/admin/frontend/templates/admin-layout.js
+++ b/src/admin/frontend/templates/admin-layout.js
@@ -23,12 +23,12 @@ class AdminLayout extends Component {
             bottom: '0px',
             width: '100%',
             paddingTop: `${this.state.offsetTop}px`,
-          }}> 
+          }}>
               <div style={{height: '100%'}}>
                   {this.props.children}
               </div>
           </div>
-      
+
           <footer>
               <script src="/bower_components/jquery/dist/jquery.min.js"></script>
               <script src="/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>

--- a/src/auth.js
+++ b/src/auth.js
@@ -34,30 +34,30 @@ passport.deserializeUser(function(obj, cb) {
 });
 
 module.exports = function(router) {
-  
+
   router.use(cookieParser());
-  
+
   const RediStore = connectRedis(session);
   const redisStore = new RediStore({
     client: redis.createClient(nconf.get('REDIS_URL')),
   });
-  
+
   router.use(session({
     secret: nconf.get('cookie_secret'),
     saveUninitialized: true,
     resave: true,
     store: redisStore.domain ? redisStore : undefined,
   }));
-  
+
   router.use(passport.initialize());
   router.use(passport.session());
-  
+
   const googleAuth = passport.authenticate('google', {
     scope: [
       'https://www.googleapis.com/auth/userinfo.email',
     ],
   });
-  
+
   function devAuth(req, res, next) {
     req.login({
       name: 'dev',
@@ -69,7 +69,7 @@ module.exports = function(router) {
       }
     });
   }
-  
+
   router.get('/admin/login', nconf.get('NODE_ENV') === 'development' ? devAuth : googleAuth);
 
   router.get('/admin/login/callback', passport.authenticate('google', {

--- a/src/browser/renderer.js
+++ b/src/browser/renderer.js
@@ -5,26 +5,26 @@ import { render } from 'react-dom';
 import nconf from 'nconf';
 import urljoin from 'url-join';
 
-import { 
-  ApolloClient, 
+import {
+  ApolloClient,
   ApolloProvider,
   createNetworkInterface,
 } from 'react-apollo';
 export function mount(Page) {
   if (typeof document !== 'undefined') {
-    
+
     const networkInterface = createNetworkInterface({
       uri: urljoin(nconf.get('SERVER_ROOT'), 'graphql'),
       opts: {
         credentials: 'same-origin',
       },
     });
-    
+
     const client = new ApolloClient({
       networkInterface,
       initialState: window.__STATE__,
     });
-    
+
     render(
       <ApolloProvider client={client}>
         <Page />

--- a/src/common/frontend/components/article-main.js
+++ b/src/common/frontend/components/article-main.js
@@ -8,47 +8,6 @@ import {getFileURL} from '../helpers/file';
 import {graphql, gql} from 'react-apollo';
 import {headData} from '~/common/frontend/head';
 
-const PARENT_QUERY = gql`
-  query ParentQuery($_id: ObjectID!) {
-    article(_id: $_id) {
-      _id
-      title
-      slug
-    }
-  }
-`;
-
-const ResponseTo = graphql(PARENT_QUERY, {
-  skip(props) {
-    return !props._id;
-  },
-  options(props) {
-    return {
-      variables: {
-        _id: props._id,
-      },
-    };
-  },
-  props({ data: { loading, article }}) {
-    return {
-      loading,
-      article,
-    };
-  },
-})( ({loading, article}) => {
-  if (loading || !article) {
-    return null;
-  } else {
-    return (
-      <div className="response-to" data-article-id={article._id}>
-          <h2>In Response To:&nbsp;
-              <a className="response-title" href={`/articles/${article.slug}`} dangerouslySetInnerHTML={{__html: article.title}}></a>
-          </h2>
-      </div>
-    );
-  }
-});
-
 const RESPONSE_ARTICLES_QUERY = gql`
 query ReponseArticles($skip: Int!, $parent: ObjectID!) {
   articleResponses(limit: 10, skip: $skip, parent: $parent) {
@@ -57,7 +16,7 @@ query ReponseArticles($skip: Int!, $parent: ObjectID!) {
     preview(length: 300)
     date
     author
-    thumb 
+    thumb
   }
 }
 `;
@@ -70,7 +29,7 @@ const ResponseArticles = graphql(gql`
       preview(length: 300)
       date
       author
-      thumb 
+      thumb
     }
     articleResponsesCount
   }
@@ -106,7 +65,7 @@ const ResponseArticles = graphql(gql`
       hasMore() {
         return articleResponses && articleResponses.length < articleResponsesCount;
       },
-    }; 
+    };
   },
 })( ({loading, articleResponses, loadMore, hasMore}) => {
   articleResponses = articleResponses || [];
@@ -116,7 +75,7 @@ const ResponseArticles = graphql(gql`
             <div className="container">
                 <h1 className="strong">Discussion</h1>
                 <div className="tile tile-vertical">
-                    {articleResponses.map((response, i) => 
+                    {articleResponses.map((response, i) =>
                         <ArticleThumb article={response} key={i} />
                     )}
                 </div>
@@ -126,6 +85,13 @@ const ResponseArticles = graphql(gql`
   );
 });
 
+const ResponseTo = ({parent}) => (
+  <div className="response-to" data-article-id={parent._id}>
+      <h2>In Response To:&nbsp;
+          <a className="response-title" href={`/articles/${parent.slug}`} dangerouslySetInnerHTML={{__html: parent.title}}></a>
+      </h2>
+  </div>
+);
 
 class ArticleMain extends Component {
   render() {
@@ -153,13 +119,16 @@ class ArticleMain extends Component {
           </Optional>
 
           <div className="container">
-              <ResponseTo _id={article.parent} />
+              <Optional test={article.parent && article.parent._id}>
+                  <ResponseTo parent={article.parent || {}} />
+              </Optional>
+
               <h1 className="article-title strong">{article.title}</h1>
               <h4 className="article-author-date thin">{article.author} &#8212; {moment(article.date).format('MMM, DD YYYY')}</h4>
               <div className="article-content" dangerouslySetInnerHTML={{__html: article.content}}></div>
 
           </div>
-          
+
           <ResponseArticles _id={article._id} />
       </div>
     );

--- a/src/common/frontend/components/feature-block.js
+++ b/src/common/frontend/components/feature-block.js
@@ -11,7 +11,7 @@ class FeatureThumb extends Component {
   render() {
     const article = this.props.article;
     return (
-      <div 
+      <div
           className={this.props.response ? 'feature-response' : 'featured'}
           style={this.props.single ? {width: '100%'} : null}>
 

--- a/src/common/frontend/components/feature-slider.js
+++ b/src/common/frontend/components/feature-slider.js
@@ -37,7 +37,7 @@ export default class FeatureSlider extends Component {
       }
     }
   }
-  
+
   checkLoadMore() {
     if (this.props.loadMore) {
       if (this.props.articles.length - this.state.idx < 2) {
@@ -54,7 +54,7 @@ export default class FeatureSlider extends Component {
   componentDidMount() {
     this.setupInterval();
   }
-  
+
   slideLeft() {
     this.setState({
       autoscroll: false,
@@ -74,7 +74,7 @@ export default class FeatureSlider extends Component {
     return (
       <div className="featured-view">
           <div className="featured-wrapper" style={{left: this.state.idx * -100 + '%'}}>
-          {articles.map((article, i) => 
+          {articles.map((article, i) =>
             <FeatureBlock article={article} key={i} />
           )}
           </div>

--- a/src/common/frontend/components/panels/archive.js
+++ b/src/common/frontend/components/panels/archive.js
@@ -42,6 +42,6 @@ export default graphql(ARCHIVE_QUERY, {
   },
 })( ({featuredArticles}) => {
   featuredArticles = featuredArticles || [];
-  
+
   return <ArchivePanel articles={featuredArticles} />;
 });

--- a/src/common/frontend/components/panels/donate.js
+++ b/src/common/frontend/components/panels/donate.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import nconf from 'nconf';
 
-class DonatePanel extends Component { 
+class DonatePanel extends Component {
   render() {
     return (
        <div className="tile tile-vertical gray-theme">
@@ -16,7 +16,7 @@ class DonatePanel extends Component {
            <img src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1" />
            <a href="#" onClick={() => { this.refs['donate-form'].submit(); }}>
              <div className="button" style={{
-               marginTop: '10px', 
+               marginTop: '10px',
                marginRight: '10px',
                marginBottom: '10px',
              }}>Contribute</div>

--- a/src/common/frontend/head.js
+++ b/src/common/frontend/head.js
@@ -71,7 +71,7 @@ export function makeHeadContext() {
         property: 'article:published_time',
       },
     },
-    link: [ 
+    link: [
       {
         href: '/img/favicon.ico',
         rel: 'icon',
@@ -109,9 +109,9 @@ export function makeHeadContext() {
       },
     ],
   };
-  
+
   class HeadContext extends Component {
-    
+
     constructor(props) {
       super(props);
 
@@ -121,12 +121,12 @@ export function makeHeadContext() {
             const paramsArray = params;
             paramsArray.forEach(params => {
               if (!data.link.map(p => p.href).includes(params.href)) {
-                data.link.push(params);  
+                data.link.push(params);
               }
             });
           } else {
             if (!data.link.map(p => p.href).includes(params.href)) {
-              data.link.push(params);  
+              data.link.push(params);
             }
           }
         },
@@ -138,24 +138,24 @@ export function makeHeadContext() {
         },
       };
     }
-  
+
     getChildContext() {
       return {
         head: this.head,
       };
     }
-    
+
     render() {
       return this.props.children;
     }
   }
-  
+
   HeadContext.childContextTypes = {
     head: PropTypes.object,
   };
-  
+
   HeadContext.data = data;
-  
+
   return HeadContext;
 }
 

--- a/src/common/frontend/helpers/page.js
+++ b/src/common/frontend/helpers/page.js
@@ -3,27 +3,27 @@ import { render } from 'react-dom';
 import nconf from 'nconf';
 import urljoin from 'url-join';
 
-import { 
-  ApolloClient, 
+import {
+  ApolloClient,
   ApolloProvider,
   createNetworkInterface,
 } from 'react-apollo';
 
 export function mount(Page, func) {
   if (typeof document !== 'undefined') {
-    
+
     const networkInterface = createNetworkInterface({
       uri: urljoin(nconf.get('SERVER_ROOT'), 'graphql'),
       opts: {
         credentials: 'same-origin',
       },
     });
-    
+
     const client = new ApolloClient({
       networkInterface,
       initialState: window.__STATE__,
     });
-    
+
     render(
       <ApolloProvider client={client}>
           <Page />

--- a/src/common/frontend/views/article.js
+++ b/src/common/frontend/views/article.js
@@ -15,7 +15,11 @@ const ARTICLE_QUERY = gql`
       author
       content
       metaDescription: preview(length: 160)
-      parent
+      parent {
+        _id
+        title
+        slug
+      }
     }
   }
 `;

--- a/src/common/frontend/views/index.js
+++ b/src/common/frontend/views/index.js
@@ -59,7 +59,7 @@ const FeatureSliderWithData = graphql(FEATURED_ARTICLES_QUERY, {
           },
         });
       },
-    }; 
+    };
   },
 })( ({loading, featuredArticles, loadMore}) => {
   return <FeatureSlider loadMore={loadMore} articles={featuredArticles} />;
@@ -116,7 +116,7 @@ const RecentArticlesWithData = graphql(gql`
             if (!fetchMoreResult) {
               return previousResult;
             }
-              
+
             return Object.assign({}, previousResult, {
               recentArticles: [...previousResult.recentArticles, ...fetchMoreResult.recentArticles],
             });
@@ -126,7 +126,7 @@ const RecentArticlesWithData = graphql(gql`
       hasMore() {
         return recentArticles.length < articleCount;
       },
-    }; 
+    };
   },
 })( ({loading, recentArticles, loadMore, hasMore}) => {
   return (

--- a/src/graphql/helpers.js
+++ b/src/graphql/helpers.js
@@ -37,7 +37,7 @@ export function applySkipLimit(query, skip, limit) {
   if (limit) {
     query = query.limit(limit);
   }
-  
+
   return query;
 }
 
@@ -49,12 +49,12 @@ export function trim(content, length, elipsis) {
   if (!content) {
     return content;
   }
-  
+
   if (elipsis) {
     length -= 3;
   }
   length = Math.max(0, length);
-  
+
   if (content.length > length) {
     content = content.substring(0, length);
     if (elipsis) {
@@ -68,11 +68,11 @@ export function htmlPreview(content, length, elipsis) {
   if (!content) {
     return content;
   }
-  
+
   content = content
     .replace(/<sup><a\b[^>]*>\[\d+\]<\/a><\/sup>/ig, '')
     .replace(/(<([^>]+)>)/ig, '')
     .replace(/&nbsp;/ig, ' ');
-    
+
   return trim(content, length, elipsis);
 }

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -19,7 +19,7 @@ export const schema = new GraphQLSchema({
       ...topicQueries,
     },
   }),
-  
+
   mutation: new GraphQLObjectType({
     name: 'RootMutation',
     fields: {
@@ -30,7 +30,7 @@ export const schema = new GraphQLSchema({
 });
 
 router.use('/', graphqlHTTP({
-  schema, 
+  schema,
   graphiql: nconf.get('NODE_ENV') === 'development',
 }));
 

--- a/src/graphql/mutations/articles.js
+++ b/src/graphql/mutations/articles.js
@@ -23,7 +23,7 @@ export const updateArticle = {
     if (!context.isAuthenticated()) {
       return Promise.reject('Not Authenticated');
     }
-    
+
     return Article.findOne({_id}).then(result => {
       Object.assign(result, article);
       return result.save(getArticleProjection(fieldASTs));
@@ -43,7 +43,7 @@ export const deleteArticle = {
     if (!context.isAuthenticated()) {
       return Promise.reject('Not Authenticated');
     }
-    
+
     return Article.findOneAndRemove({_id}, getArticleProjection(fieldASTs));
   },
 };

--- a/src/graphql/mutations/topics.js
+++ b/src/graphql/mutations/topics.js
@@ -20,7 +20,7 @@ export const newTopic = {
     if (!context.isAuthenticated()) {
       return Promise.reject('Not Authenticated');
     }
-    
+
     return (new Topic(topic)).save(getProjection(fieldASTs));
   },
 };
@@ -41,7 +41,7 @@ export const updateTopic = {
     if (!context.isAuthenticated()) {
       return Promise.reject('Not Authenticated');
     }
-    
+
     return Topic.findOne({_id}).then(result => {
       Object.assign(result, topic);
       return result.save(getProjection(fieldASTs));
@@ -61,7 +61,7 @@ export const deleteTopic = {
     if (!context.isAuthenticated()) {
       return Promise.reject('Not Authenticated');
     }
-    
+
     return Topic.findOneAndRemove({_id}, getProjection(fieldASTs));
   },
 };

--- a/src/graphql/queries/articles.js
+++ b/src/graphql/queries/articles.js
@@ -178,7 +178,7 @@ export const searchArticles = {
     }
     let q = Article.find({
       title: {
-        $regex: new RegExp(`^${title.toLowerCase()}`, 'i'),
+        $regex: new RegExp(`^${unescape(title).toLowerCase()}`, 'i'),
       },
     }, getArticleProjection(fieldASTs));
     q = applySkipLimit(q, skip, limit);

--- a/src/graphql/queries/articles.js
+++ b/src/graphql/queries/articles.js
@@ -16,7 +16,7 @@ import mongoose from 'mongoose';
 import {
   removeEmpty,
   skipLimitArgs,
-  applySkipLimit, 
+  applySkipLimit,
   authenticatedField,
 } from '../helpers';
 
@@ -44,14 +44,14 @@ export const article = {
     if (!(idOrSlug || _id || slug)) {
       return Promise.reject('No id or slug provided');
     }
-    
+
     let field = (_id || mongoose.Types.ObjectId.isValid(idOrSlug)) ? '_id' : 'slug';
-    
+
     let q = Article.findOne(removeEmpty({
       is_published: authenticatedField(context, is_published, true),
       [field]: _id || slug || idOrSlug,
     }), getArticleProjection(fieldASTs));
-    
+
     return q.exec();
   },
 };
@@ -72,12 +72,12 @@ export const articleResponses = {
     if (!parent) {
       return Promise.resolve([]);
     }
-    
+
     let q = Article.find(removeEmpty({
       is_published: authenticatedField(context, is_published, true),
       parent,
     }), getArticleProjection(fieldASTs));
-    
+
     q.sort({ date: -1 });
     q = applySkipLimit(q, skip, limit);
     return q.exec();
@@ -100,12 +100,12 @@ export const articleResponsesCount = {
     if (!parent) {
       return Promise.resolve(0);
     }
-    
+
     let q = Article.count(removeEmpty({
       is_published: authenticatedField(context, is_published, true),
       parent,
     }), getArticleProjection(fieldASTs));
-    
+
     return q.exec();
   },
 };
@@ -123,7 +123,7 @@ export const featuredArticles = {
       is_published: authenticatedField(context, is_published, true),
       is_featured: true,
     }), getArticleProjection(fieldASTs));
-    
+
     q.sort({ date: -1 });
     q = applySkipLimit(q, skip, limit);
     return q.exec();
@@ -142,7 +142,7 @@ export const recentArticles = {
     let q = Article.find(removeEmpty({
       is_published: authenticatedField(context, is_published, true),
     }), getArticleProjection(fieldASTs));
-    
+
     q.sort({ date: -1 });
     q = applySkipLimit(q, skip, limit);
     return q.exec();
@@ -161,5 +161,27 @@ export const articleCount = {
     return Article.count(removeEmpty({
       is_published: authenticatedField(context, is_published, true),
     })).exec();
+  },
+};
+
+export const searchArticles = {
+  type: new GraphQLList(ArticleType),
+  args: Object.assign({
+    title: {
+      name: 'title',
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  }, skipLimitArgs),
+  resolve: (root, {title, skip, limit}, context, fieldASTs) => {
+    if (!context.isAuthenticated()) {
+      return Promise.reject('Not authenticated');
+    }
+    let q = Article.find({
+      title: {
+        $regex: new RegExp(`^${title.toLowerCase()}`, 'i'),
+      },
+    }, getArticleProjection(fieldASTs));
+    q = applySkipLimit(q, skip, limit);
+    return q.exec();
   },
 };

--- a/src/graphql/queries/topics.js
+++ b/src/graphql/queries/topics.js
@@ -93,7 +93,7 @@ export const searchTopics = {
     }
     let q = Topic.find({
       title: {
-        $regex: new RegExp(`^${title.toLowerCase()}`, 'i'),
+        $regex: new RegExp(`^${unescape(title).toLowerCase()}`, 'i'),
       },
     }, getProjection(fieldASTs));
     q = applySkipLimit(q, skip, limit);

--- a/src/graphql/types/article.js
+++ b/src/graphql/types/article.js
@@ -23,7 +23,7 @@ export function getArticleProjection(fieldASTs) {
   return projection;
 }
 
-export default new GraphQLObjectType({
+const ArticleType = new GraphQLObjectType({
   name: 'Article',
   fields: () => ({
     _id: {
@@ -77,8 +77,19 @@ export default new GraphQLObjectType({
     thumb: {
       type: GraphQLID,
     },
-    parent: {
+    parentID: {
       type: GraphQLID,
+    },
+    parent: {
+      type: ArticleType,
+      resolve: (root, args, context, fieldASTs) => {
+        return Article.findOne({_id: root._id}, {parent: true}).then(({parent}) => {
+          if (!parent) {
+            return Promise.resolve(null);
+          }
+          return Article.findOne({_id: parent}, getArticleProjection(fieldASTs));
+        });
+      },
     },
     topicID: {
       type: GraphQLID,
@@ -92,6 +103,9 @@ export default new GraphQLObjectType({
       type: TopicType,
       resolve: (root, args, context, fieldASTs) => {
         return Article.findOne({_id: root._id}, {topic: true}).then(({topic}) => {
+          if (!topic) {
+            return Promise.resolve(null);
+          }
           return Topic.findOne({_id: topic}, getProjection(fieldASTs));
         });
       },
@@ -99,3 +113,4 @@ export default new GraphQLObjectType({
   }),
 });
 
+export default ArticleType;

--- a/src/server/renderer.js
+++ b/src/server/renderer.js
@@ -1,12 +1,12 @@
 'use strict';
 
 import React from 'react';
-import { 
+import {
   renderToString,
   renderToStaticMarkup,
 } from 'react-dom/server';
-import { 
-  ApolloClient, 
+import {
+  ApolloClient,
   ApolloProvider,
   getDataFromTree,
 } from 'react-apollo';
@@ -18,14 +18,14 @@ import Head, { makeHeadContext } from '~/common/frontend/head';
 
 function render(req, res, view, props = {}) {
   const Component = require(view.file).default;
-  
+
   const client = new ApolloClient({
     ssrMode: true,
     networkInterface: createLocalInterface(graphql, schema, {
       context: req,
     }),
   });
-  
+
   const HeadContext = makeHeadContext();
   const page = (
     <ApolloProvider client={client}>
@@ -34,7 +34,7 @@ function render(req, res, view, props = {}) {
       </HeadContext>
     </ApolloProvider>
   );
-  
+
   getDataFromTree(page).then(() => {
     const initialState = {
       apollo: client.getInitialState(),


### PR DESCRIPTION
Before we had to make separate API calls to get the parent's ID and then get the parent itself. This adds a `parent` resolver to the GraphQL `ArticleType` to simplify this. Now this is one query like:

```
article(_id: $_id) {
  _id
  title
  content
  parent {
    _id
    title
  }
}
```

The last commit adds the `no-trailing-spaces` flag. I think it will be good to enable this so that in the future, whitespace changes don't show up as modifications.

Also, I've added `npm run autoformat` to fix _some_ formatting errors caught by eslint