### PR TITLE
Image upload

### DIFF
--- a/src/admin/frontend/components/article-edit-panel.js
+++ b/src/admin/frontend/components/article-edit-panel.js
@@ -49,7 +49,12 @@ export default class ArticleEditPanel extends Component {
     if (file) {
       blob = URL.createObjectURL(file);
     }
-    this.props.stage.update(prop, blob);
+    this.props.stage.update(`${prop}_preview_img`, blob);
+    var reader = new FileReader();
+    reader.onload = () => {
+      this.props.stage.update(`${prop}_buffer`, reader.result);
+    };
+    reader.readAsDataURL(file);
   }
 
   handleSubmit(event) {
@@ -209,10 +214,10 @@ export default class ArticleEditPanel extends Component {
                   <Optional test={this.props.imagePreviews}>
                       <img
                         style={{maxWidth: '200px', display: 'block'}}
-                        src={article.cover ? getFileURL(article.cover, article.cover_preview_img) : ''}
+                        src={(article.cover || article.cover_preview_img) ? getFileURL(article.cover, article.cover_preview_img) : ''}
                       />
                   </Optional>
-                  <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'cover_preview_img')} />
+                  <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'cover')} />
               </div>
 
               <div className="form-group">
@@ -220,10 +225,10 @@ export default class ArticleEditPanel extends Component {
                   <Optional test={this.props.imagePreviews}>
                       <img
                         style={{maxWidth: '200px', display: 'block'}}
-                        src={article.thumb ? getFileURL(article.thumb, article.thumb_preview_img) : ''}
+                        src={(article.thumb || article.thumb_preview_img) ? getFileURL(article.thumb, article.thumb_preview_img) : ''}
                       />
                   </Optional>
-                  <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'thumb_preview_img')} />
+                  <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'thumb')} />
               </div>
 
               <div className="form-group">

--- a/src/admin/frontend/components/article-edit.js
+++ b/src/admin/frontend/components/article-edit.js
@@ -15,8 +15,8 @@ const editableArticleFields = [
   'date',
   'is_published',
   'is_featured',
-  'cover',
-  'thumb',
+  'cover_buffer',
+  'thumb_buffer',
   'parentID',
   'topicID',
 ];

--- a/src/admin/frontend/components/topic-edit-panel.js
+++ b/src/admin/frontend/components/topic-edit-panel.js
@@ -64,7 +64,12 @@ export default class TopicEditPanel extends Component {
     if (file) {
       blob = URL.createObjectURL(file);
     }
-    this.props.stage.update(prop, blob);
+    this.props.stage.update(`${prop}_preview_img`, blob);
+    var reader = new FileReader();
+    reader.onload = () => {
+      this.props.stage.update(`${prop}_buffer`, reader.result);
+    };
+    reader.readAsDataURL(file);
   }
 
   handleSubmit(event) {
@@ -100,17 +105,17 @@ export default class TopicEditPanel extends Component {
               <label>Cover Photo</label>
               <img
                 style={{maxWidth: '200px', display: 'block'}}
-                src={topic.cover ? getFileURL(topic.cover, topic.cover_preview_img) : ''}
+                src={(topic.cover || topic.cover_preview_img) ? getFileURL(topic.cover, topic.cover_preview_img) : ''}
               />
-              <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'cover_preview_img')} />
+              <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'cover')} />
           </div>
 
           <div className="form-group">
               <label>Thumbnail</label>
               <img
                 style={{maxWidth: '200px', display: 'block'}}
-                src={topic.thumb ? getFileURL(topic.thumb, topic.thumb_preview_img) : ''} />
-              <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'thumb_preview_img')} />
+                src={(topic.thumb || topic.thumb_preview_img) ? getFileURL(topic.thumb, topic.thumb_preview_img) : ''} />
+              <input type="file" accept="image/*" onChange={this.handleImageChange.bind(this, 'thumb')} />
           </div>
 
           <div className="form-group">

--- a/src/admin/frontend/components/topic-edit.js
+++ b/src/admin/frontend/components/topic-edit.js
@@ -11,8 +11,8 @@ const editableTopicFields = [
   'title',
   'content',
   'slug',
-  'cover',
-  'thumb',
+  'cover_buffer',
+  'thumb_buffer',
 ];
 
 class TopicEdit extends Component {

--- a/src/admin/frontend/gql/mutations.js
+++ b/src/admin/frontend/gql/mutations.js
@@ -15,7 +15,10 @@ export const ARTICLE_UPDATE = gql`
       is_featured
       cover
       thumb
-      parent
+      parent {
+        _id
+        title
+      }
       topic {
         _id
         title
@@ -38,7 +41,10 @@ export const ARTICLE_DELETE = gql`
       is_featured
       cover
       thumb
-      parent
+      parent {
+        _id
+        title
+      }
       topic {
         _id
         title

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -29,6 +29,10 @@ export const schema = new GraphQLSchema({
   }),
 });
 
+import bodyParser from 'body-parser';
+router.use(bodyParser.json({ limit: 1024 * 1024 * 2000, type: 'application/json' }));
+router.use(bodyParser.urlencoded({ extended: true, limit: 1024 * 1024 * 20, type: 'application/x-www-form-urlencoding' }));
+
 router.use('/', graphqlHTTP({
   schema,
   graphiql: nconf.get('NODE_ENV') === 'development',

--- a/src/graphql/types/articleInput.js
+++ b/src/graphql/types/articleInput.js
@@ -6,6 +6,7 @@ import {
   GraphQLString,
   GraphQLBoolean,
 } from 'graphql/type';
+import GraphQLBuffer from './buffer';
 
 import { GraphQLDateTime } from 'graphql-iso-date';
 
@@ -36,11 +37,11 @@ export default new GraphQLInputObjectType({
     slug: {
       type: GraphQLString,
     },
-    cover: {
-      type: GraphQLID,
+    cover_buffer: {
+      type: GraphQLBuffer,
     },
-    thumb: {
-      type: GraphQLID,
+    thumb_buffer: {
+      type: GraphQLBuffer,
     },
     parent: {
       type: GraphQLID,

--- a/src/graphql/types/buffer.js
+++ b/src/graphql/types/buffer.js
@@ -1,0 +1,38 @@
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLError } from 'graphql/error';
+import { Kind } from 'graphql/language';
+
+function serializeBuffer(value) {
+  if (!(value instanceof Buffer)) {
+    throw new TypeError('Field error: value is not an instance of Buffer');
+  }
+
+  return value.toString();
+}
+
+function parseBuffer(value) {
+  const regex = /^data:(.+\/.+);(.+),/;
+  var matches = value.match(regex);
+  var result = new Buffer(value.substr(matches[0].length), matches[2]);
+  result.mimeType = matches[1];
+  return result;
+}
+
+export default new GraphQLScalarType({
+  name: 'Buffer',
+  serialize: serializeBuffer,
+  parseValue: parseBuffer,
+  parseLiteral(ast) {
+    if (ast.kind !== Kind.STRING) {
+      throw new GraphQLError(`Query error: Can only parse strings to buffers but got a: ${ast.kind}`, [ast]);
+    }
+
+    const result = parseBuffer(ast.value);
+
+    if (ast.value !== result.toString()) {
+      throw new GraphQLError('Query error: Invalid buffer encoding', [ast]);
+    }
+
+    return result;
+  },
+});

--- a/src/graphql/types/topicInput.js
+++ b/src/graphql/types/topicInput.js
@@ -1,10 +1,10 @@
 'use strict';
 
 import {
-  GraphQLID,
   GraphQLInputObjectType,
   GraphQLString,
 } from 'graphql/type';
+import GraphQLBuffer from './buffer';
 
 export default new GraphQLInputObjectType({
   name: 'TopicInput',
@@ -18,11 +18,11 @@ export default new GraphQLInputObjectType({
     content: {
       type: GraphQLString,
     },
-    cover: {
-      type: GraphQLID,
+    cover_buffer: {
+      type: GraphQLBuffer,
     },
-    thumb: {
-      type: GraphQLID,
+    thumb_buffer: {
+      type: GraphQLBuffer,
     },
   },
 });


### PR DESCRIPTION
This PR adds GraphQL image uploading capability for the admin and topic cover/thumbnail images.

- The ArticleInput and TopicInput GraphQL types are updated to take an image buffer.
- There's some logic in the update mutation that deletes the previous file if it exists and replaces it with the new uploaded image